### PR TITLE
add go.mod + makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+dist/
+.dockerignore
+.editorconfig
+.gitignore
+Makefile
+README.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_size = 2
+indent_style = space
+
+[Makefile]
+indent_size = 4
+indent_style = tab
+
+[*.go]
+indent_size = 8
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-/waitsilence
+.DS_Store
+*.un~
+/.idea/
+
+/waitsilence*
+/dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,85 @@
+SHELL := bash
+
+ifeq ($(OS),Windows_NT)     # is Windows_NT on XP, 2000, 7, Vista, 10...
+	_OS := windows
+	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
+		_ARCH := amd64
+	else ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+		_ARCH := amd64
+	else
+		_ARCH := arm64
+	endif
+else
+	_OS := $(shell uname | tr '[:upper:]' '[:lower:]')
+	UNAME_M := $(shell uname -m)
+	ifeq ($(UNAME_M),x86_64)
+		_ARCH := amd64
+	else
+		_ARCH := arm64
+	endif
+endif
+
+ifeq ($(_OS),windows)
+	BINEXT := .exe
+endif
+
+.PHONY: build
+build:
+	$(MAKE) dist/$(_OS)/$(_ARCH)/waitsilence$(BINEXT)
+
+
+PHONY: build-all
+build-all: dist/linux/amd64/waitsilence dist/linux/arm64/waitsilence dist/darwin/amd64/waitsilence dist/darwin/arm64/waitsilence dist/windows/amd64/waitsilence.exe dist/windows/arm64/waitsilence.exe
+
+
+dist/linux/amd64/waitsilence:
+	docker run --rm -v '$(CURDIR)':/usr/src/app -w /usr/src/app \
+		-e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=0 \
+		--entrypoint sh \
+		golang:1.17-buster \
+		-c "go get -d -v && go build -a -v -o dist/linux/amd64/waitsilence"
+
+
+dist/linux/arm64/waitsilence:
+	docker run --rm -v '$(CURDIR)':/usr/src/app -w /usr/src/app \
+		-e GOOS=linux -e GOARCH=arm64 -e CGO_ENABLED=0 \
+		--entrypoint sh \
+		golang:1.17-buster \
+		-c "go get -d -v && go build -a -v -o dist/linux/arm64/waitsilence"
+
+
+dist/darwin/amd64/waitsilence:
+	docker run --rm -v '$(CURDIR)':/usr/src/app -w /usr/src/app \
+		-e GOOS=darwin -e GOARCH=amd64 -e CGO_ENABLED=0 \
+		--entrypoint sh \
+		golang:1.17-buster \
+		-c "go get -d -v && go build -a -v -o dist/darwin/amd64/waitsilence"
+
+
+dist/darwin/arm64/waitsilence:
+	docker run --rm -v '$(CURDIR)':/usr/src/app -w /usr/src/app \
+		-e GOOS=darwin -e GOARCH=arm64 -e CGO_ENABLED=0 \
+		--entrypoint sh \
+		golang:1.17-buster \
+		-c "go get -d -v && go build -a -v -o dist/darwin/arm64/waitsilence"
+
+
+dist/windows/amd64/waitsilence.exe:
+	docker run --rm -v '$(CURDIR)':/usr/src/app -w /usr/src/app \
+		-e GOOS=windows -e GOARCH=amd64 -e CGO_ENABLED=0 \
+		--entrypoint sh \
+		golang:1.17-buster \
+		-c "go get -d -v && go build -a -v -o dist/windows/amd64/waitsilence.exe"
+
+
+dist/windows/arm64/waitsilence.exe:
+	docker run --rm -v '$(CURDIR)':/usr/src/app -w /usr/src/app \
+		-e GOOS=windows -e GOARCH=arm64 -e CGO_ENABLED=0 \
+		--entrypoint sh \
+		golang:1.17-buster \
+		-c "go get -d -v && go build -a -v -o dist/windows/arm64/waitsilence.exe"
+
+
+PHONY: clean
+clean:
+	rm -rf '$(CURDIR)'/dist/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-waitsilence
------------
+# waitsilence
 
 Delay until `stdin` has recieved no input for a specified time, and then exit.
 
@@ -56,7 +55,6 @@ now occupy more than 1.5TB.
 
 ## Installation
 
-Use the [`go get`](//youtu.be/XCsL89YtqCs) tool, which will install it to your
-`$GOPATH`.
-
-	go get github.com/pwaller/waitsilence
+```bash
+make build
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pwaller/waitsilence
+
+go 1.17


### PR DESCRIPTION
Adding go.mod + minimal Makefile. Ideally most prolly to use something like goreleaser/github-actions to automatically build releases so users can download the binary directly without compiling locally first :)