### PR TITLE
Add go.mod for newer Golang versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pwaller/waitsilence
+
+go 1.16


### PR DESCRIPTION
This enables the project to be built with `go build` when using newer Golang versions that expect Go Modules. I'm not a particularly experienced Go developer, hopefully this is using the correct module name?

(I picked Go 1.16 arbitrarily because that's the version that's packaged for Alpine right now, and I'm trying to make a personal-use Alpine package for this)